### PR TITLE
fixes to the getTRLEN and related functions

### DIFF
--- a/gear/prfsynth/run
+++ b/gear/prfsynth/run
@@ -30,10 +30,10 @@ function die {
 }
 # How we get the tr-len out of a nifti:
 function getTRLEN {
-    TRLEN="`python -c \"import neuropythy as ny, pimms; im = ny.load('$1', to='image'); print(pimms.mag(ny.to_image_spec(im)['voxel_duration'], 'seconds')); exit();\"`"
+    TRLEN="`python -c \"import neuropythy as ny, pimms; im = ny.load('$1', to='image'); print(pimms.mag(ny.to_image_spec(im)['voxel_duration'], 'seconds')); exit();\" | sed 's/None/null/g'`"
 }
 function getFRAMES {
-    FRAMES="`python -c \"import neuropythy as ny; im = ny.load('$1', to='image'); print(np.squeeze(im.dataobj).shape[-1]); exit();\"`"
+    FRAMES="`python -c \"import neuropythy as ny, numpy as np; im = ny.load('$1', to='image'); print(np.squeeze(im.dataobj).shape[-1]); exit();\"`"
 }
 function getSLICES {
     SLICES="`python -c \"import neuropythy as ny; im = ny.load('$1', to='image'); print(im.shape[2]); exit();\"`"


### PR DESCRIPTION
This should fix some bugs related to the BIDS-ification step in prfsynth. I'm not 100% sure that these changes won't introduce some new errors, but initial tests seemed to work fine. The more important changes (not included in this pull request) are that I've fixed a minor bug in neuropythy that should get automatically incorporated into the docker the next time it is built from scratch.