### PR TITLE
Temporal feature2

### DIFF
--- a/classdefs/@prfModel/prfModel.m
+++ b/classdefs/@prfModel/prfModel.m
@@ -381,9 +381,7 @@ pm.Noise.seed=12345;
             pm.HRF               = pmHRF(pm); 
             pm.RF                = pmRF(pm);
             pm.Noise             = pmNoise(pm);
-            if strcmp(pm.Type,'st')
-                pm.Temporal          = pmTemporal(pm);
-            end
+            pm.Temporal          = pmTemporal(pm);
         end
         % Functions that apply the setting of main parameters to subclasses
         function set.TR(pm, tr)
@@ -449,9 +447,7 @@ pm.Noise.seed=12345;
                 pm.Stimulus.compute;
                 pm.RF.compute;
                 pm.HRF.compute;
-                if strcmp(pm.Type,'st')
-                    pm.Temporal.compute;
-                end
+                pm.Temporal.compute;
             end            
             % Load stimulus
             stimValues = pm.Stimulus.getStimValues;
@@ -525,6 +521,11 @@ pm.Noise.seed=12345;
                     pm.showConvolution
                     hold on
                 end
+                
+                if strcmp(pm.Type,'st')
+                   pm.BOLDconv = pm.Temporal.run_preds';
+                end
+
             % Scale the signal so that it has the required mean and contrast
             
             % Convert the output requested in pm.signalPercentage 
@@ -778,7 +779,9 @@ pm.Noise.seed=12345;
                 pm.RF.compute;
                 pm.HRF.compute;
                 pm.Noise.compute;
-                
+%                 if strcmp(pm.Type,'st')
+                    pm.Temporal.compute;
+%                 end
             end
             % Compute BOLDconv signal
             pm.computeBOLD;

--- a/functions/tables/pmForwardModelAddRows.m
+++ b/functions/tables/pmForwardModelAddRows.m
@@ -19,6 +19,25 @@ pm = prfModel;
 % variable that we want to expand
 tmp = synthDT;
 switch variableName
+    case {'Temporal'}
+        for ii=1:length(values)
+            % Add rows with the combinations of parameters we want to check
+            % Then check that the whole thing should be complete
+            complete = pmParamsCompletenessCheck(values(ii), ...
+                table2struct(pm.defaultsTable.Temporal));
+            % Check if only some of the fields in params where set
+            complete.tParams = pmParamsCompletenessCheck(complete.tParams, ...
+                pm.defaultsTable.Temporal.tParams);
+            % Convert it to table
+            fieldValuesTable = struct2table(complete,'AsArray',true);
+            % Take the copy of the existing table, and make everything equal
+            % except the one thing we are changing
+            tmp.(variableName)          = repmat(fieldValuesTable, [height(tmp),1]);
+            
+            % Now concatenate the original and the recently created one.
+            synthDT          = [synthDT; tmp];
+        end
+
     case {'HRF'}
         for ii=1:length(values)
             % Add rows with the combinations of parameters we want to check

--- a/functions/tables/pmForwardModelCalculate.m
+++ b/functions/tables/pmForwardModelCalculate.m
@@ -86,8 +86,8 @@ tmpName = tempname(fullfile(pmRootPath,'local'));
 mkdir(tmpName);
         
 tic
-parfor (nn=1:nchcks, NumWorkers)
-% for nn=1:nchcks
+% parfor (nn=1:nchcks, NumWorkers)
+for nn=1:nchcks
     DT = DTcc{nn};
     % Initialize prev variables, for parallel toolbox
     dtprev = [];
@@ -179,6 +179,25 @@ parfor (nn=1:nchcks, NumWorkers)
         end
         pm.Noise.compute;
         
+        %% Temporal [st]
+        for jj=1:width(dt.Temporal)
+            paramName          = dt.Temporal.Properties.VariableNames{jj};
+            val                = dt.Temporal.(paramName);
+            if iscell(val)
+                pm.Temporal.(paramName) = val{:};
+            else
+                pm.Temporal.(paramName) = val;
+            end
+        end
+        if ii > 1
+            if isequal(dtprev.Temporal, dt.Temporal)
+                pm.Temporal.run_preds = pmprev.Temporal.run_preds;
+            else
+                pm.Temporal.compute;
+            end
+        else
+            pm.Temporal.compute;
+        end
         %% Compute the synthetic signal
         % The compute at the top level computes all the lovel level ones.
         % Just do it once here.
@@ -301,6 +320,9 @@ else
         fName  = fullfile(tmpName, sprintf('tmpDT_%04i.mat',nn));
         tmp    = load(fName,'DT');
         DTcalc = [DTcalc; tmp.DT];
+    end
+    if strcmp(DTcalc.Type,'st') % save st predictions as matfile
+        st_saveBOLD(DTcalc,outputdir);
     end
 end
 

--- a/gear/prfsynth/synthBOLDgenerator.m
+++ b/gear/prfsynth/synthBOLDgenerator.m
@@ -188,7 +188,7 @@ if height(synthDT) > 32000
 	error("Attempting to write more than 32000 per dimension (%i). TODO: Matlab's niftiwrite will automatically use Nifti-2 to write 2^63 -1 (instead of the current 2^15 -1.", height(synthDT))
 end
 
-DTcalc = pmForwardModelCalculate(synthDT,'writefiles',true,'outputdir',output_dir,'subjectname',J.subjectName); 
+DTcalc = pmForwardModelCalculate(synthDT,'writefiles',false,'outputdir',output_dir,'subjectname',J.subjectName); 
 
 % DTcalc = pmForwardModelCalculate(synthDT, 'useparallel',J.useparallel,'writefiles',true,'outputdir',output_dir,'subjectname',J.subjectName); 
 %% Generate the files


### PR DESCRIPTION
pmStimulus.m: improved how the second range stimulus is converted to the ms Stimulus.
pmTemporal.m: cleaned temporal variables that are not used.
prfModel.m: solved the compatibility issue when temporal variable is not specified
pmForwardModelAddRows.m: read temporal attributes from the json file
